### PR TITLE
Updated support for numpy (small fix)

### DIFF
--- a/gokit.py
+++ b/gokit.py
@@ -139,7 +139,7 @@ class esbm(object):
             for i in index:
                 CB1+=[[CB_coord[count]],Y.get_residue_number(topology,i)]
                 count=count+1
-            CB1 = np.array(CB1).reshape(len(CB1) / 2, 2)
+            CB1 = np.array(CB1, dtype=object).reshape(len(CB1) // 2, 2)
             print (CB1)
             return CB1
 
@@ -175,7 +175,7 @@ class esbm(object):
              #           print COM
                         COM1 += COM
                         count = count + 1
-                COM1 = np.array(COM1).reshape(len(COM1) / 2, 2)
+                COM1 = np.array(COM1, dtype=object).reshape(len(COM1) // 2, 2)
             return COM1
 
         def get_side_chain_COM(self,pdbfile,skip_glycine):
@@ -227,7 +227,7 @@ class esbm(object):
                             #print COM
                             COM1+=COM
                         count = count + 1
-                COM1=np.array(COM1).reshape(len(COM1)/2,2)
+                COM1=np.array(COM1, dtype=object).reshape(len(COM1)//2,2)
                 #coordinates,resnum
                 # print (COM1)
                 # print (len(COM1))
@@ -373,8 +373,8 @@ class esbm(object):
             for i in range(n_res):
                CB.append([self.get_farthest_atom_in_residue(pdbfile,i),i])
 
-            #COM1 = np.array(COM1).reshape(len(COM1) / 2, 2)
-            CB=np.array(CB).reshape(len(CB),2)
+            #COM1 = np.array(COM1, dtype=object).reshape(len(COM1) // 2, 2)
+            CB=np.array(CB, dtype=object).reshape(len(CB),2)
             print (CB)
             return (CB)
 


### PR DESCRIPTION
Current versions of numpy don't support the way you are using numpy arrays for the chain information. Additionally, the version specified in requirements.txt is no longer readily available via pip.

When running the test scripts we get the following error:
```python
$ python gokit.py --w_native 1ris_clean.pdb --skip_glycine
>> in write_CB_to_native 1ris_clean.pdb False
sopc False skipglycine, True
>> in get_side_chain_COM: 1ris_clean.pdb False
<Chain id=A>
Excluding glycine, res =  34
Excluding glycine, res =  44
Excluding glycine, res =  58
Traceback (most recent call last):
  File "gokit.py", line 1616, in <module>
    main()
  File "gokit.py", line 1583, in main
    X.write_CB_to_native(pdbfile,False)
  File "gokit.py", line 251, in write_CB_to_native
    CB=self.get_side_chain_COM(pdbfile,skip_glycine)
  File "gokit.py", line 230, in get_side_chain_COM
    COM1=np.array(COM1).reshape(len(COM1)/2,2)
ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 2 dimensions. The detected shape was (188, 1) + inhomogeneous part.
```

This pull request fixes this issue. See a similar issue here: https://stackoverflow.com/questions/3386259/how-to-make-a-multidimension-numpy-array-with-a-varying-row-size

